### PR TITLE
adding aggregation job

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         FLINK_PROPERTIES=
         jobmanager.rpc.address: jobmanager
         taskmanager.numberOfTaskSlots: 15
-        parallelism.default: 3
+        parallelism.default: 1
   postgres:
     image: postgres:14
     restart: on-failure

--- a/homework.md
+++ b/homework.md
@@ -42,6 +42,8 @@ CREATE TABLE processed_events_aggregated (
     event_hour TIMESTAMP,
     num_hits INTEGER 
 );
+ALTER TABLE processed_events_aggregated
+ADD CONSTRAINT unique_event PRIMARY KEY (event_hour, test_data);
 ```
 
 Note: I rerun this command again, because once the job started the table was deleted. 

--- a/homework.md
+++ b/homework.md
@@ -36,6 +36,14 @@ CREATE TABLE processed_events (
 )
 ```
 
+```sql
+CREATE TABLE processed_events_aggregated (
+     test_data INTEGER,
+    event_hour TIMESTAMP,
+    num_hits INTEGER 
+);
+```
+
 Note: I rerun this command again, because once the job started the table was deleted. 
 I needed also to run :  Topic Existence and Auto-Creation
 ```bash

--- a/src/job/aggregation_job.py
+++ b/src/job/aggregation_job.py
@@ -35,8 +35,8 @@ def create_events_source_kafka(t_env):
             'connector' = 'kafka',
             'properties.bootstrap.servers' = 'redpanda-1:29092',
             'topic' = 'test-topic',
-            'scan.startup.mode' = 'earliest-offset',
-            'properties.auto.offset.reset' = 'earliest',
+            'scan.startup.mode' = 'latest-offset',
+            'properties.auto.offset.reset' = 'latest',
             'format' = 'json'
         );
         """
@@ -48,7 +48,7 @@ def log_aggregation():
     # Set up the execution environment
     env = StreamExecutionEnvironment.get_execution_environment()
     env.enable_checkpointing(10 * 1000)
-    env.set_parallelism(3)
+    env.set_parallelism(1)
 
     # Set up the table environment
     settings = EnvironmentSettings.new_instance().in_streaming_mode().build()
@@ -76,7 +76,7 @@ def log_aggregation():
             test_data,
             COUNT(*) AS num_hits
         FROM TABLE(
-            TUMBLE(TABLE {source_table}, DESCRIPTOR(event_watermark), INTERVAL '1' MINUTE)
+            TUMBLE(TABLE {source_table}, DESCRIPTOR(event_watermark), INTERVAL '15' SECOND)
         )
         GROUP BY window_start, test_data;
         

--- a/src/producers/producer.py
+++ b/src/producers/producer.py
@@ -15,7 +15,7 @@ t0 = time.time()
 
 topic_name = 'test-topic'
 
-for i in range(10, 1000):
+for i in range(10, 2000):
     message = {'test_data': i, 'event_timestamp': time.time() * 1000}
     producer.send(topic_name, value=message)
     print(f"Sent: {message}")


### PR DESCRIPTION
Adjustments Made to the Aggregation Job

- For the aggragation job,  we needed to set the primary key in postgres to match the DDL defined in flink and so the data can be saved in the sink.
- Due to a lack of resources I reduced the number of parallelism for the flink from 3 to 1.
- Reduced the tumbling window interval from 1 minute to 15 seconds